### PR TITLE
Rewrite Particle data handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 		<dependency>
 			<groupId>io.papermc.paper</groupId>
 			<artifactId>paper-api</artifactId>
-			<version>1.21.4-R0.1-SNAPSHOT</version>
+			<version>1.21.10-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/de/slikey/effectlib/Effect.java
+++ b/src/main/java/de/slikey/effectlib/Effect.java
@@ -40,6 +40,9 @@ public abstract class Effect implements Runnable {
     public List<Color> toColorList = null;
     public String toColors = null;
     public int shriekDelay;
+    public int trailDuration;
+    public float spellPower;
+    public float dragonBreathPower;
     public float sculkChargeRotation;
     public int arrivalTime;
     public ConfigurationSection subEffect = null;
@@ -133,27 +136,6 @@ public abstract class Effect implements Runnable {
 
     public String getToColors() {
         return toColors;
-    }
-
-    /**
-     * Used only by the shriek particle in 1.19 and up.
-     */
-    public int getShriekDelay() {
-        return shriekDelay;
-    }
-
-    /**
-     * Used only by the sculk_charge particle in 1.19 and up.
-     */
-    public float getSculkChargeRotation() {
-        return sculkChargeRotation;
-    }
-
-    /**
-     * Used only by the vibration particle in 1.17 and up.
-     */
-    public int getArrivalTime() {
-        return arrivalTime;
     }
 
     /**
@@ -504,6 +486,7 @@ public abstract class Effect implements Runnable {
     /**
      * @deprecated Use {@link #setTarget(Location)}
      */
+    @Deprecated
     public void setTargetLocation(Location location) {
         target = new DynamicLocation(location);
     }
@@ -767,8 +750,27 @@ public abstract class Effect implements Runnable {
                 currentToColor = toColorList.get(ThreadLocalRandom.current().nextInt(colorList.size()));
             }
 
-            ParticleOptions options = new ParticleOptions(particleOffsetX, particleOffsetY, particleOffsetZ, speed, amount, particleSize, currentColor, currentToColor, arrivalTime, material, materialData, blockData, blockDuration, shriekDelay, sculkChargeRotation);
-            options.target = target;
+            ParticleOptions options = new ParticleOptions(
+                    target,
+                    particleOffsetX,
+                    particleOffsetY,
+                    particleOffsetZ,
+                    speed,
+                    amount,
+                    particleSize,
+                    currentColor,
+                    currentToColor,
+                    arrivalTime,
+                    material,
+                    materialData,
+                    blockData,
+                    blockDuration,
+                    shriekDelay,
+                    trailDuration,
+                    sculkChargeRotation,
+                    dragonBreathPower,
+                    spellPower
+            );
 
             effectManager.display(particle, options, location, visibleRange, targetPlayers);
         }

--- a/src/main/java/de/slikey/effectlib/EffectManager.java
+++ b/src/main/java/de/slikey/effectlib/EffectManager.java
@@ -21,7 +21,6 @@ import java.util.concurrent.TimeUnit;
 import org.bukkit.Color;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
@@ -90,11 +89,6 @@ public class EffectManager implements Disposable {
 
     public static List<EffectManager> getManagers() {
         return effectManagers;
-    }
-
-    public void display(Particle particle, Location center, float offsetX, float offsetY, float offsetZ, float speed, int amount, float size, Color color, Material material, byte materialData, double range, List<Player> targetPlayers) {
-        ParticleOptions options = new ParticleOptions(offsetX, offsetY, offsetZ, speed, amount, size, color, material, materialData);
-        getDisplay().display(particle, options, center, range, targetPlayers);
     }
 
     public void display(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
@@ -302,7 +296,7 @@ public class EffectManager implements Disposable {
         effect.start();
         return effect;
     }
-    
+
     public void cancel(boolean callback) {
         synchronized (this) {
             if (effects == null) return;
@@ -530,11 +524,7 @@ public class EffectManager implements Disposable {
             } else if (field.getType().equals(Particle.class)) {
                 String value = fieldSection.getString(fieldKey);
                 if (value != null) {
-                    // Legacy conversions
-                    if (!ParticleDisplay.hasColorTransition() && value.equalsIgnoreCase("DUST_COLOR_TRANSITION")) {
-                        value = "REDSTONE";
-                    }
-                    var particle = ParticleUtil.getParticle(value);
+                    Particle particle = ParticleUtil.getParticle(value);
                     if (particle == null) throw new IllegalStateException("Invalid particle type '" + value.toUpperCase() + "'");
                     field.set(effect, particle);
                 }

--- a/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
+++ b/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
@@ -2,30 +2,23 @@ package de.slikey.effectlib.util;
 
 import java.util.List;
 
-import org.bukkit.Color;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.Particle;
-import org.bukkit.Vibration;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.block.data.BlockData;
 
 import de.slikey.effectlib.EffectManager;
 
 public class ParticleDisplay {
 
-    protected EffectManager manager;
+    private EffectManager manager;
 
-    private static boolean hasColorTransition = true;
-
-    protected void spawnParticle(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
+    public void display(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
         try {
             if (targetPlayers == null) {
                 double squared = range * range;
-                for (final Player player : Bukkit.getOnlinePlayers()) {
+                for (Player player : Bukkit.getOnlinePlayers()) {
                     if (!manager.isVisiblePlayer(player, center, squared)) continue;
 
                     playerDisplay(particle, options, center, player);
@@ -33,7 +26,7 @@ public class ParticleDisplay {
                 return;
             }
 
-            for (final Player player : targetPlayers) {
+            for (Player player : targetPlayers) {
                 if (manager.isPlayerIgnored(player)) continue;
 
                 playerDisplay(particle, options, center, player);
@@ -45,135 +38,24 @@ public class ParticleDisplay {
     }
 
     private void playerDisplay(Particle particle, ParticleOptions options, Location center, Player player) {
-        if (particle == Particle.valueOf("ENTITY_EFFECT")) {
-            player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.color, true);
-        } else {
-            player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.data, true);
-        }
+        player.spawnParticle(particle, center, options.amount(), options.offsetX(), options.offsetY(), options.offsetZ(), options.speed(), options.resolve(particle), true);
 
         displayFakeBlock(player, center, options);
     }
 
-    public void display(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
-        // Legacy colorizeable particles
-        if (options.color != null && particle == Particle.ENTITY_EFFECT) {
-            displayLegacyColored(particle, options, center, range, targetPlayers);
-            return;
-        }
-
-        if (particle == Particle.ITEM) {
-            displayItem(particle, options, center, range, targetPlayers);
-            return;
-        }
-
-        if (particle == Particle.BLOCK
-                || particle == Particle.FALLING_DUST
-                || particle == Particle.DUST_PILLAR) {
-            Material material = options.material;
-            if (material == null || material.name().contains("AIR")) return;
-            try {
-                options.data = material.createBlockData();
-            } catch (Exception ex) {
-                manager.onError("Error creating block data for " + material, ex);
-            }
-            if (options.data == null) return;
-        }
-
-        if (particle == Particle.DUST) {
-            // color is required
-            if (options.color == null) options.color = Color.RED;
-            options.data = new Particle.DustOptions(options.color, options.size);
-        }
-
-        if (particle == Particle.DUST_COLOR_TRANSITION) {
-            if (options.color == null) options.color = Color.RED;
-            if (options.toColor == null) options.toColor = options.color;
-            options.data = new Particle.DustTransition(options.color, options.toColor, options.size);
-        }
-
-        if (particle == Particle.VIBRATION) {
-            if (options.target == null) return;
-
-            Vibration.Destination destination;
-            Entity targetEntity = options.target.getEntity();
-            if (targetEntity != null) destination = new Vibration.Destination.EntityDestination(targetEntity);
-            else {
-                Location targetLocation = options.target.getLocation();
-                if (targetLocation == null) return;
-
-                destination = new Vibration.Destination.BlockDestination(targetLocation);
-            }
-
-            options.data = new Vibration(destination, options.arrivalTime);
-        }
-
-        if (particle == Particle.SHRIEK) {
-            if (options.shriekDelay < 0) options.shriekDelay = 0;
-            options.data = options.shriekDelay;
-        }
-
-        if (particle == Particle.SCULK_CHARGE) {
-            options.data = options.sculkChargeRotation;
-        }
-
-        spawnParticle(particle, options, center, range, targetPlayers);
-    }
-
-    protected void displayFakeBlock(final Player player, Location center, ParticleOptions options) {
-        if (options.blockData == null) return;
+    protected void displayFakeBlock(Player player, Location center, ParticleOptions options) {
+        if (options.blockData() == null) return;
         if (!center.getBlock().isPassable() && !center.getBlock().isEmpty()) return;
 
-        BlockData blockData = Bukkit.createBlockData(options.blockData.toLowerCase());
-        final Location b = center.getBlock().getLocation().clone();
+        BlockData blockData = Bukkit.createBlockData(options.blockData().toLowerCase());
+        Location b = center.getBlock().getLocation().clone();
         player.sendBlockChange(b, blockData);
 
-        Bukkit.getScheduler().runTaskLaterAsynchronously(manager.getOwningPlugin(), new Runnable() {
-            @Override
-            public void run() {
-                player.sendBlockChange(b, b.getBlock().getBlockData());
-            }
-        }, options.blockDuration);
-    }
-
-    @SuppressWarnings({"deprecation"})
-    protected void displayItem(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
-        Material material = options.material;
-        if (material == null || material.isAir()) return;
-
-        ItemStack item = new ItemStack(material);
-        item.setDurability(options.materialData);
-        options.data = item;
-        spawnParticle(particle, options, center, range, targetPlayers);
-    }
-
-    protected void displayLegacyColored(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
-        // Colored particles can't have a speed of 0.
-        Color color = options.color;
-        if (color == null) color = Color.RED;
-        if (options.speed == 0) options.speed = 1;
-        // Amount = 0 is a special flag that means use the offset as color
-        options.amount = 0;
-
-        float offsetX = (float) color.getRed() / 255;
-        float offsetY = (float) color.getGreen() / 255;
-        float offsetZ = (float) color.getBlue() / 255;
-
-        // The redstone particle reverts to red if R is 0!
-        if (offsetX < Float.MIN_NORMAL) offsetX = Float.MIN_NORMAL;
-
-        options.offsetX = offsetX;
-        options.offsetY = offsetY;
-        options.offsetZ = offsetZ;
-
-        spawnParticle(particle, options, center, range, targetPlayers);
+        Bukkit.getScheduler().runTaskLaterAsynchronously(manager.getOwningPlugin(), () -> player.sendBlockChange(b, b.getBlock().getBlockData()), options.blockDuration());
     }
 
     public void setManager(EffectManager manager) {
         this.manager = manager;
-    }
-
-    public static boolean hasColorTransition() {
-        return hasColorTransition;
     }
 
 }


### PR DESCRIPTION
### Additions:

- Added `dragonBreathPower` float option for `dragon_breath` particle.
- Added `spellPower` float option, which can be used alongside `color` to color `effect` and `instant_effect` particles.
- Added `trailDuration` integer option, which can be used alongside `color` and a target for the `trail` particle.



### Fixes:

- Fixed `color` not coloring `flash` and `tinted_leaves` particles.
- Fixed `entity_effect` particle behaving like a directional particle and ignoring `particleCount`.
- Fixed `material` support for `block_crumble` and `block_marker` particle.